### PR TITLE
send Gratuitous ARP when starting the supervisor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get -q -y update \
  && apt-get -q -y update \
  && apt-get -q -y install redis-server cron luarocks supervisor logrotate \
                           make build-essential libpcre3-dev libssl-dev wget \
+                          iputils-arping \
  && apt-get -q -y clean && rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/*
 
 ENV OPENRESTY_VERSION 1.5.8.1

--- a/supervisor/conf.d/arping.conf
+++ b/supervisor/conf.d/arping.conf
@@ -1,0 +1,4 @@
+[program:arping]
+command=bash -c 'IP=$(ip -4 addr show dev eth0 scope global | sed -nr "s/.*inet ([^/]+).*/\1/p"); /usr/bin/arping -U -c 4 $IP'
+autorestart=false
+autostart=true


### PR DESCRIPTION
This should fix the arp cache issue.
